### PR TITLE
Reformat cudnn status fix

### DIFF
--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -124,8 +124,10 @@ unique_handle<cudnnHandle_t> *nnManager(const int deviceId) {
         if (!(*handle)) { getLogger()->error("Error initalizing cuDNN"); }
     });
     if (error) {
-        string error_msg = fmt::format("Error initializing cuDNN({}): {}.",
-                                       static_cast<std::underlying_type<cudnnStatus_t>::type>(error), errorString(error));
+        string error_msg = fmt::format(
+            "Error initializing cuDNN({}): {}.",
+            static_cast<std::underlying_type<cudnnStatus_t>::type>(error),
+            errorString(error));
         AF_ERROR(error_msg, AF_ERR_RUNTIME);
     }
     CUDNN_CHECK(getCudnnPlugin().cudnnSetStream(cudnnHandles[deviceId],


### PR DESCRIPTION
Hi, as mentioned in the original PR, the code should be formatted according to the repository clang-format file for the CI tests to pass. It is just a nitpick, though. Thank you for the fix!